### PR TITLE
feat: adjust applause message

### DIFF
--- a/src/release-reminders.ts
+++ b/src/release-reminders.ts
@@ -96,7 +96,7 @@ const taskText = (task: Task) => {
 		case "recent-and-applause":
 			return "set up Recent Changes QA and Request Applause QA"
 		case "applause-review":
-			return "review Applause bugs and export them to the Applause Jira board"
+			return "export Applause bugs to the Applause Jira board"
 		case "feedback-form":
 			return "tell us how long the release took, because we are trying to optimize. Fill out this form: https://docs.google.com/forms/d/e/1FAIpQLSdfQlgk562b_Rmgz0PlFQi5a6NEELicTAXvZVPYA0nHEXMALA/viewform"
 		case "update-android-rollout-50":


### PR DESCRIPTION
# Description

Adjusted the message to reflect the current process which is that the release captain just exports all the applause bugs to the jira board