### PR TITLE
feat: only remind once, update point people

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ workflows:
   release_cadence:
     triggers:
       - schedule:
-          cron: "0 10,15 * * 1,2,3,4,5" # https://crontab.guru
+          cron: "0 10 * * 1,2,3,4,5" # https://crontab.guru
           filters:
             branches:
               only:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This bot reminds the Release Captain to do certain tasks on the day they need to
 ## Meta
 
 - **Slack App Link:** https://api.slack.com/apps/A04BAKXR83S
-- **Point People:** [@pvinis](https://github.com/pvinis)
+- **Point People:** [@gkartalis](https://github.com/gkartalis)
 
 ## How to develop
 


### PR DESCRIPTION
We have had double reminders thinking that it would be better with many of us working in different time zones, however with the release captain being tagged I'd argue we only really need the earlier one as they will see the message when they sign in. 

Also update the point people if it is alright with you @gkartalis you have the most recent contributions 😄 