### PR TITLE
chore: flip release week

### DIFF
--- a/src/release-reminders.ts
+++ b/src/release-reminders.ts
@@ -4,7 +4,7 @@ import { assertNever } from "assert-never"
 
 const web = new WebClient(process.env.SLACK_TOKEN)
 
-const firstWeekOfCadenceIsEvenWeek = true // flip this if the bot is notifying on the wrong weeks
+const firstWeekOfCadenceIsEvenWeek = false // flip this if the bot is notifying on the wrong weeks
 
 const CHANNEL = process.env.SLACK_CHANNEL ?? ""
 


### PR DESCRIPTION
With holiday schedule being funky we are again notifying on wrong week. Flip the notify week. 