### PR TITLE
feat(PHIRE-3071): feat: captain rotation logic and reminder system

### DIFF
--- a/src/__tests__/release-reminders.tests.ts
+++ b/src/__tests__/release-reminders.tests.ts
@@ -1,4 +1,33 @@
 import { getApplauseTaskText } from "../release-reminders";
+import { getCurrentCaptainIndex, getNextCaptainIndex, ROTATION_EPOCH, RELEASE_CAPTAINS } from "../constants";
+
+describe('captain rotation', () => {
+  const n = RELEASE_CAPTAINS.length;
+
+  it('returns index 0 at the epoch date', () => {
+    expect(getCurrentCaptainIndex(ROTATION_EPOCH)).toBe(0);
+  });
+
+  it('returns index 0 one week after epoch (same captain serves 2 weeks)', () => {
+    expect(getCurrentCaptainIndex(ROTATION_EPOCH.plus({ weeks: 1 }))).toBe(0);
+  });
+
+  it('advances to index 1 after two weeks', () => {
+    expect(getCurrentCaptainIndex(ROTATION_EPOCH.plus({ weeks: 2 }))).toBe(1 % n);
+  });
+
+  it('wraps back to index 0 after a full rotation', () => {
+    expect(getCurrentCaptainIndex(ROTATION_EPOCH.plus({ weeks: n * 2 }))).toBe(0);
+  });
+
+  it('getNextCaptainIndex is always (current + 1) % n', () => {
+    const anchors = [ROTATION_EPOCH, ROTATION_EPOCH.plus({ weeks: 2 }), ROTATION_EPOCH.plus({ weeks: 4 })];
+    for (const date of anchors) {
+      const current = getCurrentCaptainIndex(date);
+      expect(getNextCaptainIndex(date)).toBe((current + 1) % n);
+    }
+  });
+});
 
 describe('getApplauseTaskText', () => {
   it('should iterate through test suites properly if releases are on even weeks', () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,39 @@
 import { DateTime } from "luxon"
 
-export const firstWeekOfCadenceIsEvenWeek = true // flip this if the bot is running on the wrong weeks
+// A Thursday in a first-week-of-cadence where RELEASE_CAPTAINS[0] takes over.
+// Update this when the list is reshuffled so the index math stays correct.
+// Both functions below align to startOf('week') so Mon–Wed aren't miscounted
+// against a Thursday epoch boundary.
+export const ROTATION_EPOCH = DateTime.fromISO("2026-06-11", { zone: "utc" })
+
+const weeksSinceEpoch = (now: DateTime): number =>
+	Math.round(now.startOf("week").diff(ROTATION_EPOCH.startOf("week"), "weeks").weeks)
+
+// Epoch-based so year boundaries (week 52→1, week 53→1) don't break parity.
 export const isFirstWeekOfCadence = (now: DateTime): boolean =>
-	(firstWeekOfCadenceIsEvenWeek && now.weekNumber % 2 === 0) ||
-	(!firstWeekOfCadenceIsEvenWeek && now.weekNumber % 2 === 1)
+	((weeksSinceEpoch(now) % 2) + 2) % 2 === 0
+
+// Ordered list of Slack user IDs in rotation order.
+// Requires a PR to change — intentional for auditability.
+export const RELEASE_CAPTAINS: string[] = [
+	"URE5S7BBN", // @brian.b
+	"U01RRGTBMU3", // @ole
+	"U02CNMURE7R", // @sultan
+	"U01427GSPK9", // @mounir
+	"U023RJ49TUN", // @george
+	"U02HAF8J1QV", // @daria
+	"U02DTPDPGTA", // @carlos
+]
+
+export const CAPTAIN_DOCS_URL =
+	"https://www.notion.so/artsy/Release-Captain-Tasks-7ca3e6f5d16e41079a1fb1b1706bd018" // link to your captain runbook
+
+export const getCurrentCaptainIndex = (now: DateTime): number => {
+	const n = RELEASE_CAPTAINS.length
+	return ((Math.floor(weeksSinceEpoch(now) / 2) % n) + n) % n
+}
+
+export const getNextCaptainIndex = (now: DateTime): number => {
+	const n = RELEASE_CAPTAINS.length
+	return (getCurrentCaptainIndex(now) + 1) % n
+}

--- a/src/release-reminders.ts
+++ b/src/release-reminders.ts
@@ -1,7 +1,13 @@
 import { WebClient } from "@slack/web-api"
 import { DateTime } from "luxon"
 import { assertNever } from "assert-never"
-import { isFirstWeekOfCadence } from "./constants"
+import {
+	isFirstWeekOfCadence,
+	RELEASE_CAPTAINS,
+	CAPTAIN_DOCS_URL,
+	getCurrentCaptainIndex,
+	getNextCaptainIndex,
+} from "./constants"
 
 const web = new WebClient(process.env.SLACK_TOKEN)
 
@@ -13,9 +19,8 @@ type Task =
 	| "feedback-form"
 	| "release-notes-reminder"
 
-export const sendReleaseReminder = async () => {
+export const sendReleaseReminder = async (now = DateTime.now()) => {
 	try {
-		const now = DateTime.now()
 		const isWednesday = now.weekday === 3
 		const isThursday = now.weekday === 4
 		const isFriday = now.weekday === 5
@@ -23,57 +28,57 @@ export const sendReleaseReminder = async () => {
 
 		// MAIN LOGIC START
 		let task: Task = "skip"
+		let sendCaptainOnboarding = false
 		if (isFirstWeekOfCadence(now) && isFriday) {
 			task = "recent-and-applause"
 		}
 		if (isSecondWeekOfCadence && isWednesday) {
 			task = "feedback-form"
 		}
+		if (isSecondWeekOfCadence && isThursday) {
+			sendCaptainOnboarding = true
+		}
 		if (isFirstWeekOfCadence(now) && isThursday) {
 			task = "release-notes-reminder"
 		}
 
-		if (task === "skip") {
+		if (task === "skip" && !sendCaptainOnboarding) {
 			console.log("All good for today.")
 			return
 		}
 		// MAIN LOGIC END
 
-		const info = await web.conversations.info({
-			channel: CHANNEL,
-		})
-		const topic = info.channel?.topic?.value ?? ""
+		if (task !== "skip") {
+			const captainId = RELEASE_CAPTAINS[getCurrentCaptainIndex(now)]
 
-		const regexp = /Captain: <@(.*)>/
-		const match = topic.match(regexp)
-		const captain = match ? match[1] : null
+			let text = `Captain <@${captainId}> 🫡, don't forget to ${await taskText(
+				task,
+				now.weekNumber
+			)} today! ✨`
 
-		const users = (await web.users.list()).members!.map((m) => ({
-			id: m.id,
-			displayName: m.profile?.display_name ?? "",
-		}))
+			if (task === "release-notes-reminder") {
+				text = `${await taskText(task, now.weekNumber)}` // no need to mention the captain here
+			}
 
-		const george = users.find((m) => m.displayName === "george")?.id ?? ""
-		const brian = users.find((m) => m.displayName === "brian.b")?.id ?? ""
-
-		let text = captain
-			? `Captain <@${captain}> 🫡, don't forget to ${await taskText(
-					task,
-					now.weekNumber
-			  )} today! ✨`
-			: `There is no Release Captain set <@${george}> <@${brian}>! Make sure to add one on the channel's topic. Someone should ${await taskText(
-					task,
-					now.weekNumber
-			  )} today!`
-
-		if (task === "release-notes-reminder") {
-			text = `${await taskText(task, now.weekNumber)}` // no need to mention the captain here
+			await web.chat.postMessage({
+				channel: CHANNEL,
+				text,
+			})
 		}
 
-		await web.chat.postMessage({
-			channel: CHANNEL,
-			text,
-		})
+		if (sendCaptainOnboarding) {
+			const nextCaptainId = RELEASE_CAPTAINS[getNextCaptainIndex(now)]
+			await web.chat.postMessage({
+				channel: CHANNEL,
+				text: `Hey <@${nextCaptainId}>! Your Release Captain rotation starts tomorrow. Here's everything you need to know: ${CAPTAIN_DOCS_URL}`,
+			})
+			await web.conversations.setTopic({
+				channel: CHANNEL,
+				topic: `Captain: <@${nextCaptainId}>`,
+			})
+			console.log(`Updated channel topic to incoming captain <@${nextCaptainId}>.`)
+		}
+
 		console.log("Successfully sent reminder.")
 	} catch (error) {
 		console.error("Error while sending reminder. See below:")
@@ -84,11 +89,12 @@ export const sendReleaseReminder = async () => {
 const getGroupHandles = async () => {
 	// add or edit the team handles here
 	const teamHandles = [
-		"mp-pals",
-		"emerald-devs",
-		"topaz-devs",
-		"onyx-devs",
-		"diamond-devs",
+		"george", // --- IGNORE --- replace with real handles before deploying
+		// "mp-pals",
+		// "emerald-devs",
+		// "topaz-devs",
+		// "onyx-devs",
+		// "diamond-devs",
 	]
 
 	const groups = (await web.usergroups.list()).usergroups?.map((g) => ({

--- a/src/release-reminders.ts
+++ b/src/release-reminders.ts
@@ -89,12 +89,11 @@ export const sendReleaseReminder = async (now = DateTime.now()) => {
 const getGroupHandles = async () => {
 	// add or edit the team handles here
 	const teamHandles = [
-		"george", // --- IGNORE --- replace with real handles before deploying
-		// "mp-pals",
-		// "emerald-devs",
-		// "topaz-devs",
-		// "onyx-devs",
-		// "diamond-devs",
+		"mp-pals",
+		"emerald-devs",
+		"topaz-devs",
+		"onyx-devs",
+		"diamond-devs",
 	]
 
 	const groups = (await web.usergroups.list()).usergroups?.map((g) => ({

--- a/src/test-send.ts
+++ b/src/test-send.ts
@@ -1,0 +1,24 @@
+import * as dotenv from "dotenv"
+dotenv.config()
+
+import { DateTime } from "luxon"
+import { sendReleaseReminder } from "./release-reminders"
+
+/**
+ * Manually trigger a reminder for a given date.
+ * Usage: npx ts-node src/test-send.ts [YYYY-MM-DD]  (defaults to today if omitted)
+ *
+ * Use #bot-testing to avoid spamming #practice-mobile channel.
+ * To inspect output without posting to Slack, add a console.log in sendReleaseReminder
+ * and comment out the web.chat.postMessage calls.
+ */
+const dateArg = process.argv[2]
+const date = dateArg ? DateTime.fromISO(dateArg, { zone: "local" }) : DateTime.now()
+
+if (!date.isValid) {
+  console.error(`Invalid date: ${dateArg}`)
+  process.exit(1)
+}
+
+console.log(`Simulating: ${date.toISODate()} (${date.weekdayLong}, week ${date.weekNumber})`)
+sendReleaseReminder(date)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "@tsconfig/node18/tsconfig.json"
+  "extends": "@tsconfig/node18/tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  }
 }


### PR DESCRIPTION
## Description 

Replaces the manual "Captain: `<@user>`" channel topic lookup with an epoch-based rotation list. The rotation advances every two weeks, aligns to week boundaries to avoid year-boundary parity bugs, and wraps around automatically.

Changes:
- constants.ts: adds RELEASE_CAPTAINS (ordered Slack user ID list), ROTATION_EPOCH, and getCurrentCaptainIndex / getNextCaptainIndex helpers
- release-reminders.ts: uses the rotation index instead of parsing the channel topic; adds Thursday onboarding message to the incoming captain with a link to the runbook, and auto-updates the channel topic
- test-send.ts: new dev utility to simulate a reminder for any date via CLI (npx ts-node src/test-send.ts YYYY-MM-DD)
- Tests covering rotation index math, wrap-around, and getNextCaptainIndex

### Follow ups:

Once this is merged we can get rid of the ops genie rotation
