### PR TITLE
feat: add Eigen changelog to the release-candidate PR description

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@artsy/changelog": "file:../changelog",
     "@slack/web-api": "6.9.1",
     "assert-never": "1.2.1",
     "dotenv": "16.0.3",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@artsy/changelog": "file:../changelog",
+    "@artsy/changelog": "^0.1.0",
     "@slack/web-api": "6.9.1",
     "assert-never": "1.2.1",
     "dotenv": "16.0.3",

--- a/src/__tests__/changelog.tests.ts
+++ b/src/__tests__/changelog.tests.ts
@@ -1,0 +1,146 @@
+import {
+	compareVersions,
+	extractPrNumbers,
+	generateChangelogMarkdown,
+	pickPreviousRcBranch,
+	renderChangelog,
+} from "../changelog"
+
+const mockFetch = jest.fn()
+global.fetch = mockFetch
+
+describe("compareVersions", () => {
+	it("orders numerically, not lexically", () => {
+		expect(compareVersions("9.8.0", "9.12.0")).toBeLessThan(0)
+		expect(compareVersions("9.12.0", "9.8.0")).toBeGreaterThan(0)
+		expect(compareVersions("9.8.0", "9.8.0")).toBe(0)
+		expect(compareVersions("10.0.0", "9.99.99")).toBeGreaterThan(0)
+	})
+})
+
+describe("pickPreviousRcBranch", () => {
+	const refs = [
+		"refs/heads/rc-v9.8.0",
+		"refs/heads/rc-v9.12.0",
+		"refs/heads/rc-v9.10.0",
+		"refs/heads/main",
+		"refs/heads/some-feature",
+	]
+
+	it("picks the highest version strictly older than the current one", () => {
+		expect(pickPreviousRcBranch(refs, "9.12.0")).toBe("rc-v9.10.0")
+	})
+
+	it("excludes the current version", () => {
+		expect(pickPreviousRcBranch(["refs/heads/rc-v9.12.0"], "9.12.0")).toBeNull()
+	})
+
+	it("returns null when there is no older rc branch", () => {
+		expect(pickPreviousRcBranch(["refs/heads/main"], "9.12.0")).toBeNull()
+		expect(pickPreviousRcBranch(["refs/heads/rc-v9.13.0"], "9.12.0")).toBeNull()
+	})
+})
+
+describe("extractPrNumbers", () => {
+	it("extracts squash-merge and merge-commit PR numbers and de-duplicates in order", () => {
+		expect(
+			extractPrNumbers([
+				"feat: add thing (#101)",
+				"Merge pull request #102 from artsy/branch",
+				"chore: noise without a number",
+				"fix: again (#101)", // dupe
+				"fix: another (#103)",
+			])
+		).toEqual([101, 102, 103])
+	})
+})
+
+describe("renderChangelog", () => {
+	it("groups by section in fixed order, uses ### headers, and attributes author + PR", () => {
+		const md = renderChangelog({
+			crossPlatformUserFacingChanges: [{ entry: "Cross thing", author: "alice", prNumber: 1 }],
+			iOSUserFacingChanges: [{ entry: "iOS thing", author: "bob", prNumber: 2 }],
+			androidUserFacingChanges: [],
+			devChanges: [{ entry: "Dev thing", author: "carol", prNumber: 3 }],
+		})
+		expect(md).toBe(
+			[
+				"### Cross-platform user-facing changes",
+				"- Cross thing — alice (#1)",
+				"",
+				"### iOS user-facing changes",
+				"- iOS thing — bob (#2)",
+				"",
+				"### Dev changes",
+				"- Dev thing — carol (#3)",
+			].join("\n")
+		)
+		expect(md).not.toContain("#### ")
+	})
+
+	it("returns null when there are no entries", () => {
+		expect(
+			renderChangelog({
+				crossPlatformUserFacingChanges: [],
+				iOSUserFacingChanges: [],
+				androidUserFacingChanges: [],
+				devChanges: [],
+			})
+		).toBeNull()
+	})
+})
+
+describe("generateChangelogMarkdown", () => {
+	beforeEach(() => {
+		jest.clearAllMocks()
+		jest.spyOn(console, "log").mockImplementation(() => {})
+	})
+
+	afterEach(() => jest.restoreAllMocks())
+
+	it("returns null when there is no previous RC branch", async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: async () => [{ ref: "refs/heads/rc-v9.12.0" }],
+		})
+
+		expect(await generateChangelogMarkdown("9.12.0")).toBeNull()
+		expect(mockFetch).toHaveBeenCalledTimes(1)
+	})
+
+	it("builds changelog markdown from the PRs between the previous RC branch and main", async () => {
+		mockFetch
+			.mockResolvedValueOnce({
+				ok: true,
+				json: async () => [{ ref: "refs/heads/rc-v9.11.0" }, { ref: "refs/heads/rc-v9.12.0" }],
+			}) // matching-refs -> previous = rc-v9.11.0
+			.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					total_commits: 2,
+					commits: [
+						{ commit: { message: "feat: shiny thing (#101)" } },
+						{ commit: { message: "chore: skip me (#102)" } },
+					],
+				}),
+			}) // compare
+			.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					body: "### Changelog updates\n#### iOS user-facing changes\n- Fixed input focus styles",
+					user: { login: "alice" },
+				}),
+			}) // PR 101
+			.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({ body: "#nochangelog", user: { login: "bob" } }),
+			}) // PR 102 -> skipped
+
+		const md = await generateChangelogMarkdown("9.12.0")
+
+		expect(md).toBe("### iOS user-facing changes\n- Fixed input focus styles — alice (#101)")
+		expect(mockFetch).toHaveBeenCalledTimes(4)
+		const comparedUrl = mockFetch.mock.calls[1][0].toString()
+		expect(comparedUrl).toContain("/compare/rc-v9.11.0...main")
+	})
+})

--- a/src/__tests__/create-release-candidate.tests.ts
+++ b/src/__tests__/create-release-candidate.tests.ts
@@ -29,6 +29,7 @@ const mockSuccessfulGithubCalls = () => {
 		.mockResolvedValueOnce({ ok: true, json: async () => ({ tree: { sha: "tree123" } }) }) // GET commit
 		.mockResolvedValueOnce({ ok: true, json: async () => ({ sha: "newcommit123" }) }) // POST empty commit
 		.mockResolvedValueOnce({ ok: true, json: async () => ({}) }) // PATCH branch ref
+		.mockResolvedValueOnce({ ok: true, json: async () => [{ ref: "refs/heads/rc-v9.8.0" }] }) // GET matching-refs (only current branch -> no previous -> no changelog)
 		.mockResolvedValueOnce({ ok: true, json: async () => ({ number: 123, html_url: "https://github.com/artsy/eigen/pull/123" }) }) // POST PR
 		.mockResolvedValueOnce({ ok: true, json: async () => ({}) }) // POST labels
 }
@@ -67,7 +68,7 @@ describe("createReleaseCandidate", () => {
 
 		await createReleaseCandidate()
 
-		expect(mockFetch).toHaveBeenCalledTimes(8)
+		expect(mockFetch).toHaveBeenCalledTimes(9)
 		expect(console.log).toHaveBeenCalledWith(
 			"Successfully created RC branch rc-v9.8.0 and PR #123"
 		)
@@ -86,6 +87,46 @@ describe("createReleaseCandidate", () => {
 		expect(prBody.title).toBe("chore(release): v9.8.0 RC")
 		expect(prBody.body).toContain("#nochangelog")
 		expect(prBody.body).toContain("⚠️")
+	})
+
+	it("injects the generated changelog into the PR body when a previous RC branch exists", async () => {
+		jest.spyOn(DateTime, "now").mockReturnValue(RC_FRIDAY)
+		mockFetch
+			.mockResolvedValueOnce({ ok: true, json: async () => ({ content: appJsonContent }) }) // GET app.json
+			.mockResolvedValueOnce({ ok: true, json: async () => ({ object: { sha: "abc123" } }) }) // GET main ref
+			.mockResolvedValueOnce({ ok: true, json: async () => ({}) }) // POST create branch
+			.mockResolvedValueOnce({ ok: true, json: async () => ({ tree: { sha: "tree123" } }) }) // GET commit
+			.mockResolvedValueOnce({ ok: true, json: async () => ({ sha: "newcommit123" }) }) // POST empty commit
+			.mockResolvedValueOnce({ ok: true, json: async () => ({}) }) // PATCH branch ref
+			.mockResolvedValueOnce({
+				ok: true,
+				json: async () => [{ ref: "refs/heads/rc-v9.7.0" }, { ref: "refs/heads/rc-v9.8.0" }],
+			}) // GET matching-refs -> previous = rc-v9.7.0
+			.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					total_commits: 1,
+					commits: [{ commit: { message: "feat: thing (#101)" } }],
+				}),
+			}) // GET compare
+			.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					body: "#### iOS user-facing changes\n- Fixed a thing",
+					user: { login: "alice" },
+				}),
+			}) // GET PR 101
+			.mockResolvedValueOnce({ ok: true, json: async () => ({ number: 123, html_url: "https://github.com/artsy/eigen/pull/123" }) }) // POST PR
+			.mockResolvedValueOnce({ ok: true, json: async () => ({}) }) // POST labels
+
+		await createReleaseCandidate()
+
+		const prCall = mockFetch.mock.calls.find((call) => call[0].toString().endsWith("/pulls"))
+		const prBody = JSON.parse(prCall[1].body)
+		expect(prBody.body).toContain("## Changelog")
+		expect(prBody.body).toContain("### iOS user-facing changes")
+		expect(prBody.body).toContain("- Fixed a thing — alice (#101)")
+		expect(prBody.body).toContain("#nochangelog")
 	})
 
 	it("throws when version cannot be found in app.json", async () => {

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -1,0 +1,163 @@
+import { changelogTemplateSections, parsePRDescription } from "@artsy/changelog"
+import { github } from "./github"
+
+const OWNER = "artsy"
+const REPO = "eigen"
+const PER_PAGE = 250
+
+type SectionKey = keyof typeof changelogTemplateSections
+
+// Fixed display order for the rendered changelog.
+const SECTION_ORDER: SectionKey[] = [
+	"crossPlatformUserFacingChanges",
+	"iOSUserFacingChanges",
+	"androidUserFacingChanges",
+	"devChanges",
+]
+
+interface ChangelogEntry {
+	entry: string
+	author: string
+	prNumber: number
+}
+
+type SectionedEntries = Record<SectionKey, ChangelogEntry[]>
+
+const emptySections = (): SectionedEntries => ({
+	crossPlatformUserFacingChanges: [],
+	iOSUserFacingChanges: [],
+	androidUserFacingChanges: [],
+	devChanges: [],
+})
+
+// --- pure helpers (exported for tests) ---
+
+export const parseVersion = (version: string): number[] =>
+	version.split(".").map((part) => parseInt(part, 10) || 0)
+
+// Numeric semver-ish comparison: negative if a < b, positive if a > b, 0 if equal.
+export const compareVersions = (a: string, b: string): number => {
+	const pa = parseVersion(a)
+	const pb = parseVersion(b)
+	const len = Math.max(pa.length, pb.length)
+	for (let i = 0; i < len; i++) {
+		const da = pa[i] ?? 0
+		const db = pb[i] ?? 0
+		if (da !== db) return da - db
+	}
+	return 0
+}
+
+// From a list of git ref names, pick the most recent `rc-v{version}` branch whose version is
+// strictly older than `currentVersion` (the just-created current RC branch is excluded).
+export const pickPreviousRcBranch = (refNames: string[], currentVersion: string): string | null => {
+	const versions = refNames
+		.map((ref) => ref.replace(/^refs\/heads\//, ""))
+		.filter((name) => /^rc-v\d+(\.\d+)*$/.test(name))
+		.map((name) => name.slice("rc-v".length))
+		.filter((version) => compareVersions(version, currentVersion) < 0)
+		.sort(compareVersions)
+
+	if (versions.length === 0) return null
+	return `rc-v${versions[versions.length - 1]}`
+}
+
+// Pull PR numbers out of commit messages (squash merges: `(#123)`, or merge commits).
+export const extractPrNumbers = (messages: string[]): number[] => {
+	const seen = new Set<number>()
+	const result: number[] = []
+	for (const message of messages) {
+		const match = message.match(/\(#(\d+)\)/m) || message.match(/Merge pull request #(\d+)/m)
+		if (!match) continue
+		const prNumber = parseInt(match[1], 10)
+		if (!seen.has(prNumber)) {
+			seen.add(prNumber)
+			result.push(prNumber)
+		}
+	}
+	return result
+}
+
+export const renderChangelog = (sections: SectionedEntries): string | null => {
+	const blocks: string[] = []
+	for (const key of SECTION_ORDER) {
+		const entries = sections[key]
+		if (!entries || entries.length === 0) continue
+		const lines = entries.map((e) => `- ${e.entry} — ${e.author} (#${e.prNumber})`)
+		// Use `###` (not `####`) so this rendered summary can never be re-parsed as
+		// changelog source by eigen's own tooling.
+		blocks.push(`### ${changelogTemplateSections[key]}\n${lines.join("\n")}`)
+	}
+	if (blocks.length === 0) return null
+	return blocks.join("\n\n")
+}
+
+// --- GitHub-fetching pipeline ---
+
+interface GitRef {
+	ref: string
+}
+
+interface CompareResponse {
+	total_commits: number
+	commits: Array<{ commit: { message: string } }>
+}
+
+interface PullResponse {
+	body: string | null
+	user: { login: string } | null
+}
+
+const fetchCommitMessages = async (base: string, head: string): Promise<string[]> => {
+	const messages: string[] = []
+	let page = 1
+	let total = Infinity
+	while (messages.length < total) {
+		const compare = await github<CompareResponse>(
+			`https://api.github.com/repos/${OWNER}/${REPO}/compare/${base}...${head}?per_page=${PER_PAGE}&page=${page}`
+		)
+		total = compare.total_commits
+		for (const c of compare.commits) messages.push(c.commit.message)
+		if (compare.commits.length === 0) break
+		page++
+	}
+	return messages
+}
+
+// Builds the changelog markdown for the release `version` by diffing the previous RC branch
+// against eigen's `main` and parsing the changelog sections out of each merged PR.
+// Returns null when there is no previous RC branch or no changelog entries.
+export const generateChangelogMarkdown = async (version: string): Promise<string | null> => {
+	const refs = await github<GitRef[]>(
+		`https://api.github.com/repos/${OWNER}/${REPO}/git/matching-refs/heads/rc-v`
+	)
+	const previousBranch = pickPreviousRcBranch(
+		refs.map((r) => r.ref),
+		version
+	)
+	if (!previousBranch) {
+		console.log("No previous RC branch found; skipping changelog generation.")
+		return null
+	}
+
+	console.log(`Generating changelog: ${previousBranch}...main`)
+	const messages = await fetchCommitMessages(previousBranch, "main")
+	const prNumbers = extractPrNumbers(messages)
+
+	const sections = emptySections()
+	for (const prNumber of prNumbers) {
+		const pr = await github<PullResponse>(
+			`https://api.github.com/repos/${OWNER}/${REPO}/pulls/${prNumber}`
+		)
+		const parsed = parsePRDescription(pr.body ?? "")
+		if (parsed.type !== "changes") continue
+		const author = pr.user?.login ?? "unknown"
+		for (const key of SECTION_ORDER) {
+			for (const entry of parsed[key]) {
+				sections[key].push({ entry, author, prNumber })
+			}
+		}
+	}
+
+	return renderChangelog(sections)
+}

--- a/src/create-release-candidate.ts
+++ b/src/create-release-candidate.ts
@@ -3,29 +3,13 @@ dotenv.config()
 
 import { WebClient } from "@slack/web-api"
 import { DateTime } from "luxon"
+import { generateChangelogMarkdown } from "./changelog"
 import { isFirstWeekOfCadence } from "./constants"
+import { github } from "./github"
 
-const GITHUB_TOKEN = process.env.GITHUB_TOKEN ?? ""
 const SLACK_CHANNEL = process.env.SLACK_CHANNEL ?? ""
 
 const web = new WebClient(process.env.SLACK_TOKEN)
-
-const github = async <T = unknown>(url: string, options?: RequestInit): Promise<T> => {
-	const res = await fetch(url, {
-		...options,
-		headers: {
-			Authorization: `Bearer ${GITHUB_TOKEN}`,
-			Accept: "application/vnd.github+json",
-			"X-GitHub-Api-Version": "2022-11-28",
-			"Content-Type": "application/json",
-		},
-	})
-	if (!res.ok) {
-		const body = await res.text()
-		throw new Error(`GitHub API error ${res.status}: ${body}`)
-	}
-	return res.json() as Promise<T>
-}
 
 export const createReleaseCandidate = async () => {
 	const now = DateTime.now()
@@ -81,6 +65,25 @@ export const createReleaseCandidate = async () => {
 		body: JSON.stringify({ sha: emptyCommit.sha }),
 	})
 
+	// Best-effort: a changelog failure must never block RC creation.
+	let changelog: string | null = null
+	try {
+		changelog = await generateChangelogMarkdown(version)
+	} catch (error) {
+		console.error("Failed to generate changelog (continuing without it):", error)
+	}
+
+	const body = [
+		`## Release Candidate ${version}`,
+		``,
+		`This branch was automatically created as the release candidate for version ${version}.`,
+		``,
+		`> ⚠️ Do not merge this PR. It is used for tracking the release and 🍒 cherry-picking fixes only.`,
+		...(changelog ? [``, `## Changelog`, ``, changelog] : []),
+		``,
+		`#nochangelog`,
+	].join("\n")
+
 	const pr = await github<{ number: number; html_url: string }>(
 		"https://api.github.com/repos/artsy/eigen/pulls",
 		{
@@ -89,7 +92,7 @@ export const createReleaseCandidate = async () => {
 				title: `chore(release): v${version} RC`,
 				head: branchName,
 				base: "main",
-				body: `## Release Candidate ${version}\n\nThis branch was automatically created as the release candidate for version ${version}.\n\n> ⚠️ Do not merge this PR. It is used for tracking the release and 🍒 cherry-picking fixes only.\n\n#nochangelog`,
+				body,
 			}),
 		}
 	)

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,0 +1,16 @@
+export const github = async <T = unknown>(url: string, options?: RequestInit): Promise<T> => {
+	const res = await fetch(url, {
+		...options,
+		headers: {
+			Authorization: `Bearer ${process.env.GITHUB_TOKEN ?? ""}`,
+			Accept: "application/vnd.github+json",
+			"X-GitHub-Api-Version": "2022-11-28",
+			"Content-Type": "application/json",
+		},
+	})
+	if (!res.ok) {
+		const body = await res.text()
+		throw new Error(`GitHub API error ${res.status}: ${body}`)
+	}
+	return res.json() as Promise<T>
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,8 +10,10 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@artsy/changelog@file:../changelog":
+"@artsy/changelog@^0.1.0":
   version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@artsy/changelog/-/changelog-0.1.0.tgz#ab8c9d866298bd99749bc4d0bc0983655f37b65a"
+  integrity sha512-nzWF92kF+voLhtkAepnUhszM3xfzwKkrh/b8pb+WQFNpr38hfN7pQhPRCTC0jNqo7U70d0hqokyc0orqES/Dvw==
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.25.7":
   version "7.25.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,9 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
+"@artsy/changelog@file:../changelog":
+  version "0.1.0"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.25.7":
   version "7.25.7"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.25.7.tgz#438f2c524071531d643c6f0188e1e28f130cebc7"


### PR DESCRIPTION
## What

This PR updates the body of rhe release cadidate PR to include the changelog 

## Motivation

@olerichter00 reached out recently to run the script, and it's an easy thing to do but it's annoying if you don't have some environment variables or broken environment because you are working on something else. So I figured out, why not have this with the release candidate PR

Related Repo: https://github.com/artsy/artsy-changelog
Related EIgen PR: https://github.com/artsy/eigen/pull/13700


Assisted-by: Claude:Opus-4.8