### PR TITLE
feat: source the release captain from Orbit

### DIFF
--- a/src/orbit.ts
+++ b/src/orbit.ts
@@ -1,0 +1,134 @@
+import { DateTime } from "luxon"
+import {
+	RELEASE_CAPTAINS,
+	getCurrentCaptainIndex,
+	getNextCaptainIndex,
+} from "./constants"
+
+/**
+ * Orbit integration (proof of concept).
+ *
+ * Orbit (github.com/artsy/orbit) is Artsy's on-call rotation scheduler. Instead
+ * of hardcoding the captain list + rotation math in `constants.ts`, we can ask
+ * Orbit who is on call — and get overrides/shift-swaps applied for free.
+ *
+ * This module fetches Orbit's computed schedule for the "Release Captain"
+ * rotation and returns the current + next captain as Slack user IDs. It is
+ * OPT-IN via env vars and falls back to the local `constants.ts` math when
+ * unset, so behaviour is unchanged until Orbit is wired up:
+ *
+ *   ORBIT_URL          e.g. https://orbit.artsy.net
+ *   ORBIT_ROTATION_ID  the Release Captain rotation's id
+ *   ORBIT_TOKEN        a service token (see the note on auth below)
+ *
+ * NOTE ON AUTH: Orbit's API currently requires an interactive next-auth session
+ * (Gravity `team` role), which a headless bot can't obtain. Using Orbit from
+ * here needs Orbit to accept a service token for read access — that's the main
+ * adjustment tracked on the Orbit side. Until then, leave the env vars unset
+ * and this module no-ops to the local fallback.
+ */
+
+// Minimal shapes of the bits of Orbit's `GET /api/rotations/[id]/schedule`
+// response we consume (see Orbit's `ScheduleResponse` / `Engineer`).
+interface OrbitEngineer {
+	id: string
+	slackUserId: string | null
+}
+
+interface OrbitScheduleEntry {
+	periodStart: string // ISO
+	periodEnd: string // ISO (exclusive)
+	effectiveEngineerId: string | null
+}
+
+export interface Captains {
+	current: string
+	next: string
+}
+
+const readConfig = () => {
+	const url = process.env.ORBIT_URL
+	const rotationId = process.env.ORBIT_ROTATION_ID
+	if (!url || !rotationId) return null
+	return { url, rotationId, token: process.env.ORBIT_TOKEN }
+}
+
+const authHeaders = (token?: string): Record<string, string> =>
+	token ? { Authorization: `Bearer ${token}` } : {}
+
+const fetchJson = async <T>(url: string, token?: string): Promise<T> => {
+	const res = await fetch(url, { headers: authHeaders(token) })
+	if (!res.ok) {
+		throw new Error(`Orbit request failed (${res.status}): ${url}`)
+	}
+	return (await res.json()) as T
+}
+
+/** The local, hardcoded fallback — the behaviour that shipped before Orbit. */
+export const resolveCaptainsLocally = (now: DateTime): Captains => ({
+	current: RELEASE_CAPTAINS[getCurrentCaptainIndex(now)],
+	next: RELEASE_CAPTAINS[getNextCaptainIndex(now)],
+})
+
+/**
+ * Ask Orbit who's on call now and next, mapped to Slack user IDs. Returns
+ * `null` when Orbit isn't configured or the lookup fails, so callers can fall
+ * back to the local math.
+ */
+export const resolveCaptainsFromOrbit = async (
+	now: DateTime
+): Promise<Captains | null> => {
+	const config = readConfig()
+	if (!config) return null
+
+	try {
+		const start = now.toUTC().toISO()
+		// Two cadences ahead is plenty to always contain "current" and "next".
+		const end = now.plus({ weeks: 4 }).toUTC().toISO()
+
+		const schedule = await fetchJson<{ entries: OrbitScheduleEntry[] }>(
+			`${config.url}/api/rotations/${config.rotationId}/schedule?start=${encodeURIComponent(
+				start ?? ""
+			)}&end=${encodeURIComponent(end ?? "")}`,
+			config.token
+		)
+		const engineers = await fetchJson<OrbitEngineer[]>(
+			`${config.url}/api/engineers`,
+			config.token
+		)
+
+		const slackIdByEngineer = new Map(
+			engineers.map((e) => [e.id, e.slackUserId])
+		)
+
+		const sorted = [...schedule.entries].sort(
+			(a, b) =>
+				DateTime.fromISO(a.periodStart).toMillis() -
+				DateTime.fromISO(b.periodStart).toMillis()
+		)
+		const nowMs = now.toMillis()
+		const currentIndex = sorted.findIndex(
+			(e) =>
+				DateTime.fromISO(e.periodStart).toMillis() <= nowMs &&
+				nowMs < DateTime.fromISO(e.periodEnd).toMillis()
+		)
+		if (currentIndex === -1) return null
+
+		const currentSlack = slackIdByEngineer.get(
+			sorted[currentIndex].effectiveEngineerId ?? ""
+		)
+		const nextSlack = slackIdByEngineer.get(
+			sorted[currentIndex + 1]?.effectiveEngineerId ?? ""
+		)
+		if (!currentSlack || !nextSlack) return null
+
+		return { current: currentSlack, next: nextSlack }
+	} catch (error) {
+		console.error("Orbit lookup failed; falling back to local rotation.", error)
+		return null
+	}
+}
+
+/** Prefer Orbit when configured; otherwise use the local `constants.ts` math. */
+export const resolveCaptains = async (now: DateTime): Promise<Captains> =>
+	(await resolveCaptainsFromOrbit(now)) ?? resolveCaptainsLocally(now)

--- a/src/release-reminders.ts
+++ b/src/release-reminders.ts
@@ -1,13 +1,8 @@
 import { WebClient } from "@slack/web-api"
 import { DateTime } from "luxon"
 import { assertNever } from "assert-never"
-import {
-	isFirstWeekOfCadence,
-	RELEASE_CAPTAINS,
-	CAPTAIN_DOCS_URL,
-	getCurrentCaptainIndex,
-	getNextCaptainIndex,
-} from "./constants"
+import { isFirstWeekOfCadence, CAPTAIN_DOCS_URL } from "./constants"
+import { resolveCaptains } from "./orbit"
 
 const web = new WebClient(process.env.SLACK_TOKEN)
 
@@ -48,9 +43,13 @@ export const sendReleaseReminder = async (now = DateTime.now()) => {
 		}
 		// MAIN LOGIC END
 
-		if (task !== "skip") {
-			const captainId = RELEASE_CAPTAINS[getCurrentCaptainIndex(now)]
+		// Who's on call now / next — from Orbit when configured, else the local
+		// rotation math (see ./orbit).
+		const { current: captainId, next: nextCaptainId } = await resolveCaptains(
+			now
+		)
 
+		if (task !== "skip") {
 			let text = `Captain <@${captainId}> 🫡, don't forget to ${await taskText(
 				task,
 				now.weekNumber
@@ -67,7 +66,6 @@ export const sendReleaseReminder = async (now = DateTime.now()) => {
 		}
 
 		if (sendCaptainOnboarding) {
-			const nextCaptainId = RELEASE_CAPTAINS[getNextCaptainIndex(now)]
 			await web.chat.postMessage({
 				channel: CHANNEL,
 				text: `Hey <@${nextCaptainId}>! Your Release Captain rotation starts tomorrow. Here's everything you need to know: ${CAPTAIN_DOCS_URL}`,


### PR DESCRIPTION
**Draft — for inspiration, not to merge.** Shows what it would look like to let [Orbit](https://github.com/artsy/orbit) (Artsy's on-call rotation scheduler) drive the Release Captain instead of the hardcoded list + rotation math in `constants.ts`.

## Local Testing
<img width="864" height="159" alt="Screenshot 2026-07-31 at 09 29 01" src="https://github.com/user-attachments/assets/88f4e52a-b809-41eb-a180-3b9f0cd977bc" />


## What this does
- **`src/orbit.ts`** — fetches Orbit's computed schedule for the Release Captain rotation and maps the on-call engineer (`effectiveEngineerId`) to a Slack user ID, returning the **current** and **next** captain. Opt-in via `ORBIT_URL` / `ORBIT_ROTATION_ID` / `ORBIT_TOKEN`; **falls back to today's `constants.ts` math** when unset, so behavior is unchanged by default.
- **`release-reminders.ts`** — resolves the captain via `resolveCaptains(now)` (Orbit → fallback) rather than reading `RELEASE_CAPTAINS[getCurrentCaptainIndex(now)]` directly.

## Why
Orbit already models exactly this rotation (ordered round-robin + biweekly cadence + anchor date) and adds **overrides and shift-swaps** — so "who's on call" reflects real-life coverage changes without editing this repo. On the Orbit side I've seeded a matching "Release Captain" rotation and given engineers a `slackUserId` so the bot can `@mention` them.

## Open item before this is real
Orbit's API is authenticated with an interactive next-auth session (Gravity `team` role), which a headless bot can't obtain. Using Orbit from here needs Orbit to accept a **service token for read access** — see the note at the top of `src/orbit.ts`. Until then the env vars stay unset and the local fallback runs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKQn1QibQsnUP3CPqPBJ5z)_